### PR TITLE
Update instruction to install and add default port

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Create disposable online [Planning Poker](http://en.wikipedia.org/wiki/Planning_
 ##Installation
 
     npm install -d
-    node app
+    node server
 
 [http://localhost:5000](http://localhost:5000)
 

--- a/server.js
+++ b/server.js
@@ -9,8 +9,8 @@ var express = require('express'),
 
 // Prefix paths with tool name
 var basedir = '/hatjitsu';
-// Use port provided by portgrabber
-var port = process.env.PORT;
+// Use port provided by portgrabber or default to 5000
+var port = process.env.PORT || 5000;
 
 var app = module.exports = express.createServer();
 var io = require('socket.io').listen(app, { resource: basedir + '/socket.io' });


### PR DESCRIPTION
* `node server` installs the app, not `node app`. 
* Added a default port. Portgrabber doesn't seem to work for me. Not entirely sure how it's supposed to work even. 